### PR TITLE
fix: re-export ResultItem at crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use into_sql::{IntoSql, IntoSqlOwned};
 pub use protocol::{
     EncryptionLevel,
     numeric::Numeric,
-    pipeline::ResultStream,
+    pipeline::{ResultItem, ResultStream},
     temporal,
     wire::{
         BulkImport, ColumnAttribute, DataType, FixedLenType, IntoRowMessage, RowMessage, SqlValue,


### PR DESCRIPTION
Pounce needs `tabby::ResultItem` to iterate query results. This was in the feature branch but missing from main after merge.